### PR TITLE
Configure documentation to compile with tut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# sbt
+lib_managed
+project/project
+target
+
+# Worksheets (Eclipse or IntelliJ)
+*.sc
+
+# Eclipse
+.cache*
+.classpath
+.project
+.scala_dependencies
+.settings
+.target
+.worksheet
+
+# IntelliJ
+.idea
+
+# ENSIME
+.ensime
+.ensime_lucene
+.ensime_cache
+
+# Mac
+.DS_Store
+
+# Vim
+.*.sw[a-z]
+*.un~
+Session.vim
+
+# Windows
+Thumbs.db
+Desktop.ini
+

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,13 @@ lazy val core = project
   .settings(publishSettings: _*)
   .settings(scalaMacroDependencies: _*)
   .settings(moduleName := "totalitarian")
+  .settings(
+    Seq(
+      tutSourceDirectory := baseDirectory.value / "..",
+      tutNameFilter := "README\\.md".r
+    )
+  )
+  .enablePlugins(TutPlugin)
 
 lazy val examples = project
   .in(file("examples"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"     % "1.1.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("org.tpolecat"      % "tut-plugin"  % "0.5.5")
+


### PR DESCRIPTION
For this some general configuration (sbt, gitignore, sbt-plugins) had to be added first.
Upon running `tut` only the main project `README.md` will be processed.

### Changes

* add missing sbt configuration to make project buildable
* add `.gitignore` file
* add and configure `tut` to run on the main project `README.md`
* fixes #3 
